### PR TITLE
add naive approach for resizing the images

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -9,3 +9,25 @@ and creating data loaders for efficient batching of the data during training and
 Obserservations:
 Images from the dataset are of different sizes.
 """
+
+import os
+from PIL import Image
+
+
+def resize_image(image_dir, output_dir, target_size=(256, 256)):
+    """
+    Resize images to target size and save them to output directory.
+    Currently only supports .jpg and .png images.
+    It's worth noting that resize will stretch and sometimes rotate Images.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+
+    for image_name in os.listdir(image_dir):
+        if image_name.lower().endswith((".jpg", ".png")):
+            image_path = os.path.join(image_dir, image_name)
+            image = Image.open(image_path)
+
+            resized_image = image.resize(target_size)
+
+            output_path = os.path.join(output_dir, image_name)
+            resized_image.save(output_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ tqdm
 opencv-python
 numpy
 pandas
-PIL 
+Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ tqdm
 opencv-python
 numpy
 pandas
+PIL 


### PR DESCRIPTION
Currently Images are stretched to fit 256x256 causing change in aspect ratio.
somehow rotation occurs sometimes which led me to the idea that our CNN should be able to detect that as well - what do you think?  

I read [here on cs.se](https://cs.stackexchange.com/questions/134628/how-does-cnn-deal-with-rotation-invariant-pictures) that a simple method would be to just rotate training images randomly and train for more epochs. 

